### PR TITLE
remove unused import

### DIFF
--- a/devices.py
+++ b/devices.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import dbus
-import bluezutils
 
 ADAPTER_DEV = "hci0"
 


### PR DESCRIPTION
bluezuitl is not used in this file, removing the dependency makes this file much more portable.

Thank you for the code, it's a nice example of python dbus and bluetooth